### PR TITLE
Fix Shell errors

### DIFF
--- a/bin/dc-restart
+++ b/bin/dc-restart
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-dc-stop $@ && dc-start $@
+dc-stop "$@" && dc-start "$@"

--- a/bin/dc-start
+++ b/bin/dc-start
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-docker-compose up -d $@ && docker-compose logs -f $@
+docker-compose up -d "$@" && docker-compose logs -f "$@"

--- a/bin/dc-stop
+++ b/bin/dc-stop
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-docker-compose stop $@ && docker-compose rm -f $@
+docker-compose stop "$@" && docker-compose rm -f "$@"

--- a/bin/docker-brennen
+++ b/bin/docker-brennen
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 
 stopped_containers=$(docker ps -qa --no-trunc --filter "status=exited")
-[[ -n "${stopped_containers}" ]] && docker rm ${stopped_containers} 2>/dev/null
+[[ -n "${stopped_containers}" ]] && docker rm "${stopped_containers}" 2>/dev/null
 
 dangling_images=$(docker images --filter "dangling=true" -q --no-trunc)
-[[ -n "${dangling_images}" ]] && docker rmi ${dangling_images} 2>/dev/null
+[[ -n "${dangling_images}" ]] && docker rmi "${dangling_images}" 2>/dev/null
 
 no_tag_images=$(docker images | grep "none" | awk '/ / { print $3 }')
-[[ -n "${no_tag_images}" ]] && docker rmi ${no_tag_images} 2>/dev/null
+[[ -n "${no_tag_images}" ]] && docker rmi "${no_tag_images}" 2>/dev/null
 
 bridge_networks=$(docker network ls | grep "bridge" | awk '/ / { print $1 }')
-[[ -n "${bridge_networks}" ]] && docker network rm ${bridge_networks} 2>/dev/null
+[[ -n "${bridge_networks}" ]] && docker network rm "${bridge_networks}" 2>/dev/null
 
 dangling_volumes=$(docker volume ls -qf dangling=true)
-[[ -n "${dangling_volumes}" ]] && docker volume rm ${dangling_volumes} 2>/dev/null
+[[ -n "${dangling_volumes}" ]] && docker volume rm "${dangling_volumes}" 2>/dev/null


### PR DESCRIPTION
This fixes errors and warnings reported by shellcheck:

- [`SC2068`](https://www.shellcheck.net/wiki/SC2068): Double quote array expansions to avoid re-splitting elements.
- [`SC2086`](https://www.shellcheck.net/wiki/SC2086): Double quote to prevent globbing and word splitting.